### PR TITLE
changing the formatiing of file_prefix in tiff_stack

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8
 git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
-suitcase-utils[test_fixtures] >=0.1.0rc2
+suitcase-utils[test_fixtures] >=0.1.4rc1
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib

--- a/suitcase/tiff_stack/tests/tests.py
+++ b/suitcase/tiff_stack/tests/tests.py
@@ -42,7 +42,8 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
 
     for name, doc in collector:
         if name == 'start':
-            templated_file_prefix = file_prefix.format(**doc).partition('-')[0]
+            templated_file_prefix = file_prefix.format(
+                start=doc).partition('-')[0]
             break
 
     if artifacts:


### PR DESCRIPTION
This updates the `file_prefix` formatting in `tiff_stack` to match that in `tiff_series`.

##Previous approach
`file_prefix='{uid}'`
##New approach
`file_prefix='{start[uid]}'`