### PR TITLE
Avoid broken tifffile release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # List required packages in this file, one per line.
 event-model >=1.8.0
 suitcase-utils
-tifffile
+tifffile !=2019.7.26.2


### PR DESCRIPTION
Tifffile issued a bad release on 3 December that makes the package not importable. Importing (on Linux) raises

```
ModuleNotFoundError: No module named 'imagecodecs'
```

There was also a report from scikit-image confirming this, though I can't readily find the link.

The nightly CI build did not catch this---you can see the [build history](https://travis-ci.org/bluesky/suitcase-tiff/builds) is fully green because [an older, working version of tifffile had been cached and was used](https://travis-ci.org/bluesky/suitcase-tiff/builds/622058615#L193). The error manifested in CI of other projects, including https://github.com/bluesky/bluesky-darkframes/pull/14.