### PR TITLE
Use descriptor to filter fields.

### DIFF
--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -4,6 +4,7 @@ import itertools
 import numpy
 from suitcase import tiff_stack
 from tifffile import TiffWriter
+import warnings
 from ._version import get_versions
 
 __version__ = get_versions()['version']
@@ -234,20 +235,25 @@ class Serializer(tiff_stack.Serializer):
         stream_name = descriptor.get('name')
         for field in doc['data']:
             img = doc['data'][field]
-            # check that the data is 2D, if not ignore it
-            img_asarray = numpy.asarray(img, dtype=self._astype)
-            if img_asarray.ndim == 2:
-                # template the file name.
-                num = next(self._counter[stream_name][field])
-                filename = get_prefixed_filename(
-                    file_prefix=self._file_prefix,
-                    start_doc=self._start,
-                    descriptor_doc=descriptor,
-                    event_doc=doc,
-                    num=num,
-                    stream_name=stream_name,
-                    field=field
-                )
+            # Check that the data is 2D or 3D; if not ignore it.
+            data_key = descriptor['data_keys'][field]
+            ndim = len(data_key['shape'] or [])
+            if data_key['dtype'] == 'array' and 1 < ndim < 4:
+                img_asarray = numpy.asarray(img, dtype=self._astype)
+                if ndim == 3:
+                    # Reduce to 2D using mean.
+                    img_asarray = np.mean(img_asarray, 0)
+                    num = next(self._counter[stream_name][field])
+                    filename = get_prefixed_filename(
+                        file_prefix=self._file_prefix,
+                        start_doc=self._start,
+                        descriptor_doc=descriptor,
+                        event_doc=doc,
+                        num=num,
+                        stream_name=stream_name,
+                        field=field
+                    )
+
                 file = self._manager.open('stream_data', filename, 'xb')
                 tw = TiffWriter(file, **self._init_kwargs)
                 self._tiff_writers[stream_name][field+f'-{num}'] = tw

--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -242,23 +242,26 @@ class Serializer(tiff_stack.Serializer):
             ndim = len(data_key['shape'] or [])
             if data_key['dtype'] == 'array' and 1 < ndim < 4:
                 img_asarray = numpy.asarray(img, dtype=self._astype)
-                if ndim == 3:
-                    # Reduce to 2D using mean.
-                    img_asarray = np.mean(img_asarray, 0)
-                num = next(self._counter[stream_name][field])
-                filename = get_prefixed_filename(
-                    file_prefix=self._file_prefix,
-                    start_doc=self._start,
-                    descriptor_doc=descriptor,
-                    event_doc=doc,
-                    num=num,
-                    stream_name=stream_name,
-                    field=field
-                )
-                file = self._manager.open('stream_data', filename, 'xb')
-                tw = TiffWriter(file, **self._init_kwargs)
-                self._tiff_writers[stream_name][field+f'-{num}'] = tw
-                tw.save(img_asarray, *self._kwargs)
+                if ndim == 2:
+                    # handle 2D data just like 3D data
+                    # by adding a 3rd dimension
+                    img_asarray = numpy.expand_dims(img_asarray, axis=0)
+                for i in range(img_asarray.shape[0]):
+                    img_asarray_2d = img_asarray[i, :]
+                    num = next(self._counter[stream_name][field])
+                    filename = get_prefixed_filename(
+                        file_prefix=self._file_prefix,
+                        start_doc=self._start,
+                        descriptor_doc=descriptor,
+                        event_doc=doc,
+                        num=num,
+                        stream_name=stream_name,
+                        field=field
+                    )
+                    file = self._manager.open('stream_data', filename, 'xb')
+                    tw = TiffWriter(file, **self._init_kwargs)
+                    self._tiff_writers[stream_name][field+f'-{num}'] = tw
+                    tw.save(img_asarray_2d, *self._kwargs)
 
 
 def get_prefixed_filename(

--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -243,17 +243,16 @@ class Serializer(tiff_stack.Serializer):
                 if ndim == 3:
                     # Reduce to 2D using mean.
                     img_asarray = np.mean(img_asarray, 0)
-                    num = next(self._counter[stream_name][field])
-                    filename = get_prefixed_filename(
-                        file_prefix=self._file_prefix,
-                        start_doc=self._start,
-                        descriptor_doc=descriptor,
-                        event_doc=doc,
-                        num=num,
-                        stream_name=stream_name,
-                        field=field
-                    )
-
+                num = next(self._counter[stream_name][field])
+                filename = get_prefixed_filename(
+                    file_prefix=self._file_prefix,
+                    start_doc=self._start,
+                    descriptor_doc=descriptor,
+                    event_doc=doc,
+                    num=num,
+                    stream_name=stream_name,
+                    field=field
+                )
                 file = self._manager.open('stream_data', filename, 'xb')
                 tw = TiffWriter(file, **self._init_kwargs)
                 self._tiff_writers[stream_name][field+f'-{num}'] = tw

--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
-import event_model
 import itertools
+
 import numpy
-from suitcase import tiff_stack
 from tifffile import TiffWriter
-import warnings
+
+import event_model
+from suitcase import tiff_stack
+
 from ._version import get_versions
 
 __version__ = get_versions()['version']

--- a/suitcase/tiff_series/tests/tests.py
+++ b/suitcase/tiff_series/tests/tests.py
@@ -1,3 +1,13 @@
+from collections import defaultdict
+import itertools
+import os
+from pathlib import Path
+
+import numpy
+from numpy.testing import assert_array_equal
+import pytest
+import tifffile
+
 import event_model
 from .. import export
 import numpy

--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -1,9 +1,12 @@
 from collections import defaultdict
 from pathlib import Path
-from tifffile import TiffWriter
-import event_model
+
 import numpy
+from tifffile import TiffWriter
+
+import event_model
 import suitcase.utils
+
 from ._version import get_versions
 
 __version__ = get_versions()['version']

--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -275,6 +275,21 @@ class Serializer(event_model.DocumentRouter):
                 data_key = descriptor['data_keys'][field]
                 ndim = len(data_key['shape'] or [])
                 if data_key['dtype'] == 'array' and 1 < ndim < 4:
+                    # there is data to be written so
+                    # create a file for this stream and field
+                    # if one does not exist yet
+                    if not self._tiff_writers.get(stream_name, {}).get(field):
+                        filename = get_prefixed_filename(
+                            file_prefix=self._file_prefix,
+                            start_doc=self._start,
+                            stream_name=stream_name,
+                            field=field
+                        )
+                        file = self._manager.open('stream_data', filename, 'xb')
+                        tw = TiffWriter(file, **self._init_kwargs)
+                        self._tiff_writers[stream_name][field] = tw
+
+                    # write the data
                     img_asarray = numpy.asarray(img, dtype=self._astype)
                     if ndim == 2:
                         # handle 2D data just like 3D data
@@ -282,17 +297,6 @@ class Serializer(event_model.DocumentRouter):
                         img_asarray = numpy.expand_dims(img_asarray, axis=0)
                     for i in range(img_asarray.shape[0]):
                         img_asarray_2d = img_asarray[i, :]
-                        # create a file for this stream and field if required
-                        if not self._tiff_writers.get(stream_name, {}).get(field):
-                            filename = get_prefixed_filename(
-                                file_prefix=self._file_prefix,
-                                start_doc=self._start,
-                                stream_name=stream_name,
-                                field=field
-                            )
-                            file = self._manager.open('stream_data', filename, 'xb')
-                            tw = TiffWriter(file, **self._init_kwargs)
-                            self._tiff_writers[stream_name][field] = tw
                         # append the image to the file
                         tw = self._tiff_writers[stream_name][field]
                         tw.save(img_asarray_2d, *self._kwargs)

--- a/suitcase/tiff_stack/tests/tests.py
+++ b/suitcase/tiff_stack/tests/tests.py
@@ -85,17 +85,21 @@ def test_file_prefix_stream_name_field_formatting(example_data, tmp_path):
             self._descriptors[doc['uid']] = doc
 
         def event_page(self, doc):
+            descriptor = self._descriptors[doc['descriptor']]
             for field in doc['data']:
-                filename = Path(
-                    get_prefixed_filename(
-                        file_prefix=file_prefix,
-                        start_doc=self._start_doc,
-                        field=field,
-                        stream_name=self._descriptors[doc['descriptor']]['name']
+                data_key = descriptor['data_keys'][field]
+                ndim = len(data_key['shape'] or [])
+                if data_key['dtype'] == 'array' and 1 < ndim < 4:
+                    filename = Path(
+                        get_prefixed_filename(
+                            file_prefix=file_prefix,
+                            start_doc=self._start_doc,
+                            field=field,
+                            stream_name=descriptor['name']
+                        )
                     )
-                )
 
-                self.expected_file_paths.add(str(tmp_path / filename))
+                    self.expected_file_paths.add(str(tmp_path / filename))
 
     fp_collector = ExpectedFilePathCollector()
     for name, doc_ in collector:


### PR DESCRIPTION
In the original draft of this, if I recall correctly, @awalter-bnl and I
both agreed that we should inspect that array's actual shape to decide
whether it was suitable for writing as TIFF. In a better world, we would
rely on the EventDescriptor for this, but at that time it was known that
many EventDescriptor were not correct and we didn't want suitcase-tiff
to be blocked by a database migration to fix them.

Now, databroker 1.0 gives us a hook to patch erroneous EventDescriptors
using "transforms", and it also gives us new urgency to ensure they
are correct. (If not, dask explodes.) It might be time to rely on them
being correct here as well.

The immediately motivation for this issue is that suitcase-tiff blows up
on strings, which it tries to cast to numpy arrays. Much safer to check
the dtype and shape in the descriptor.