### PR TITLE
Support {stream_name} and {field} in file prefix

### DIFF
--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -55,6 +55,9 @@ def export(gen, directory, file_prefix='{start[uid]}-', astype='uint16',
         ``{start[uid]}-`` which is guaranteed to be present and unique. A more
         descriptive value depends on the application and is therefore left to
         the user.
+        Two additional template parameters ``{stream_name}`` and ``{field}``
+        are supported. These will be replaced with stream name and detector
+        name, respectively.
 
     astype : numpy dtype
         The image array is converted to this type before being passed to

--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -248,7 +248,7 @@ class Serializer(event_model.DocumentRouter):
 
             The data in Events might be structured as an Event, an EventPage,
             or a "bulk event" (deprecated). The DocumentRouter base class takes
-            care of first transforming the other repsentations into an
+            care of first transforming the other representations into an
             EventPage and then routing them through here, so no further action
             is required in this class. We can assume we will always receive an
             EventPage.

--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -156,7 +156,7 @@ class Serializer(event_model.DocumentRouter):
         ``{start[uid]}-`` which is guaranteed to be present and unique. A more
         descriptive value depends on the application and is therefore left to
         the user.
-        Two additional template parameters ``{streamname}`` and ``{field}``
+        Two additional template parameters ``{stream_name}`` and ``{field}``
         are supported. These will be replaced with stream name and detector
         name, respectively.
 
@@ -271,29 +271,21 @@ class Serializer(event_model.DocumentRouter):
                     img, dtype=numpy.dtype(self._astype))
                 if img_asarray.ndim == 2:
                     # create a file for this stream and field if required
-                    streamname = self._descriptors[doc['descriptor']].get('name')
-                    if not self._tiff_writers.get(streamname, {}).get(field):
-                        filename = self._get_prefixed_filename(
+                    stream_name = self._descriptors[doc['descriptor']].get('name')
+                    if not self._tiff_writers.get(stream_name, {}).get(field):
+                        filename = get_prefixed_filename(
                             file_prefix=self._file_prefix,
                             start_doc=self._start,
-                            streamname=streamname,
+                            stream_name=stream_name,
                             field=field
                         )
                         file = self._manager.open(
                             'stream_data', filename, 'xb')
                         tw = TiffWriter(file, **self._init_kwargs)
-                        self._tiff_writers[streamname][field] = tw
+                        self._tiff_writers[stream_name][field] = tw
                     # append the image to the file
-                    tw = self._tiff_writers[streamname][field]
+                    tw = self._tiff_writers[stream_name][field]
                     tw.save(img_asarray, *self._kwargs)
-
-    @staticmethod
-    def _get_prefixed_filename(file_prefix, start_doc, streamname, field):
-        '''Assemble the prefixed filename.'''
-        templated_file_prefix = file_prefix.format(
-            start=start_doc, field=field, streamname=streamname)
-        filename = f'{templated_file_prefix}{streamname}-{field}.tiff'
-        return filename
 
     def stop(self, doc):
         self.close()
@@ -314,3 +306,11 @@ class Serializer(event_model.DocumentRouter):
 
     def __exit__(self, *exception_details):
         self.close()
+
+
+def get_prefixed_filename(file_prefix, start_doc, stream_name, field):
+    '''Assemble the prefixed filename.'''
+    templated_file_prefix = file_prefix.format(
+        start=start_doc, field=field, stream_name=stream_name)
+    filename = f'{templated_file_prefix}{stream_name}-{field}.tiff'
+    return filename

--- a/suitcase/tiff_stack/tests/tests.py
+++ b/suitcase/tiff_stack/tests/tests.py
@@ -5,7 +5,7 @@ import tifffile
 from numpy.testing import assert_array_equal
 
 from event_model import DocumentRouter
-from .. import export, Serializer
+from .. import export, get_prefixed_filename
 from suitcase.tiff_series.tests.tests import create_expected
 
 
@@ -26,8 +26,8 @@ def test_export(tmp_path, example_data):
 
     for filename in artifacts.get('stream_data', []):
         actual = tifffile.imread(str(filename))
-        streamname = os.path.basename(filename).split('-')[0]
-        assert_array_equal(actual, expected[streamname])
+        stream_name = os.path.basename(filename).split('-')[0]
+        assert_array_equal(actual, expected[stream_name])
 
 
 def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
@@ -56,20 +56,20 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
         assert unique_actual == set([templated_file_prefix])
 
 
-def test_file_prefix_streamname_field_formatting(example_data, tmp_path):
+def test_file_prefix_stream_name_field_formatting(example_data, tmp_path):
     '''
     Runs a test of ``file_prefix`` formatting including ``field``
-    and ``streamname``.
+    and ``stream_name``.
 
     ..note::
 
-        Due to the `example_data` `pytest.fixture this will run multiple tests
+        Due to the `example_data` `pytest.fixture` this will run multiple tests
         each with a range of detectors and event_types. See `suitcase.utils.conftest`
         for more info.
 
     '''
     collector = example_data()
-    file_prefix = "test-{streamname}-{field}/{start[uid]}-"
+    file_prefix = "test-{stream_name}-{field}/{start[uid]}-"
     artifacts = export(collector, tmp_path, file_prefix=file_prefix)
 
     class ExpectedFilePathCollector(DocumentRouter):
@@ -87,11 +87,11 @@ def test_file_prefix_streamname_field_formatting(example_data, tmp_path):
         def event_page(self, doc):
             for field in doc['data']:
                 filename = Path(
-                    Serializer._get_prefixed_filename(
+                    get_prefixed_filename(
                         file_prefix=file_prefix,
                         start_doc=self._start_doc,
                         field=field,
-                        streamname=self._descriptors[doc['descriptor']]['name']
+                        stream_name=self._descriptors[doc['descriptor']]['name']
                     )
                 )
 


### PR DESCRIPTION
This PR adds support for two new template parameters in the file prefix: {stream_name} and {field}. These parameters take the same values used to construct the file name
```
<directory>/<file_prefix>{stream_name}-{field}.tiff
```