### PR TITLE
ENH/API: add zero-padding to the frame number

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     env:
       TZ: America/New_York

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.8", "3.9"]
+        python-version: ["3.8", "3.8", "3.9", "3.10"]
       fail-fast: false
     env:
       TZ: America/New_York

--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -300,7 +300,6 @@ def get_prefixed_filename(
         stream_name=stream_name,
         field=field
     )
-    frame_number = f"{{num:0{pad}d}}".format(num=num)
     filename = (f'{templated_file_prefix}'
-                f'{stream_name}-{field}-{frame_number}.tiff')
+                f'{stream_name}-{field}-{num:0{pad}d}.tiff')
     return filename

--- a/suitcase/tiff_series/tests/tests.py
+++ b/suitcase/tiff_series/tests/tests.py
@@ -105,7 +105,8 @@ def test_path_formatting(file_prefix, example_data, tmp_path):
                         event_doc=event_doc,
                         num=num,
                         stream_name=stream_name,
-                        field=field
+                        field=field,
+                        pad=5,
                     )
                     self.expected_file_paths.add(Path(tmp_path) / Path(filename))
 


### PR DESCRIPTION
This was identified by @danolds and 


---

I am getting alot of local failures that look like with and these changes, seeing if CI agrees:

```
_______________________________________________________________________________________________ test_file_prefix_stream_name_field_formatting[one_stream_multi_descriptors_plan-<lambda>-event_page] _______________________________________________________________________________________________

example_data = <function example_data.<locals>._example_data_func at 0x7f127067e8b0>, tmp_path = PosixPath('/tmp/pytest-of-tcaswell/pytest-12/test_file_prefix_stream_name_f35')

    def test_file_prefix_stream_name_field_formatting(example_data, tmp_path):
        '''
        Runs a test of ``file_prefix`` formatting including ``field``
        and ``stream_name``.
    
        ..note::
    
            Due to the `example_data` `pytest.fixture` this will run multiple tests
            each with a range of detectors and event_types. See `suitcase.utils.conftest`
            for more info.
    
        '''
        collector = example_data()
        file_prefix = "test-{stream_name}-{field}/{start[uid]}-"
>       artifacts = export(collector, tmp_path, file_prefix=file_prefix)

suitcase/tiff_stack/tests/tests.py:73: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
suitcase/tiff_stack/__init__.py:115: in export
    serializer(*item)
suitcase/tiff_stack/__init__.py:322: in __exit__
    self.close()
suitcase/tiff_stack/__init__.py:316: in close
    self._manager.close()
../../../../.virtualenvs/sys38/lib/python3.8/site-packages/suitcase/utils/__init__.py:266: in close
    a.handle.close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def wrapped_close():
>       handle.seek(0, os.SEEK_END)
E       ValueError: seek of closed file

../../../../.virtualenvs/sys38/lib/python3.8/site-packages/suitcase/utils/__init__.py:93: ValueError


```