### PR TITLE
DOC: release notes for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # suitcase-tiff changes
 
+## v0.4.0 (2022-05-10)
+
+- Fix to deal with descriptors that lie about the shape.
+- Add zero-padding to the frame number in the exported files.
+- CI updates to use GitHub Actions for checking style, testing, and publishing to PyPI.
+- Fix versioneer compatibility with Python 3.11.
+
+## v0.3.0 (2021-03-29)
+
 ## v0.2.1 (2019-12-07)
 
 ## v0.2.0 (2019-05-28)


### PR DESCRIPTION
Changes: https://github.com/bluesky/suitcase-tiff/compare/v0.3.0...e61d147df8fd1c3593b044f871a5d352347f2d2d.